### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # step-security/reviewdog-action-setup
 
 This action installs :dog: [reviewdog](https://github.com/reviewdog/reviewdog).

--- a/action.yml
+++ b/action.yml
@@ -15,14 +15,14 @@ runs:
         ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
         DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
 
-        echo ""
-        echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
-        echo "Secure drop-in replacement for $UPSTREAM"
+        printf '\n'
+        printf '\033[1;36mStepSecurity Maintained Action\033[0m\n'
+        printf 'Secure drop-in replacement for %s\n' "$UPSTREAM"
         if [ "$REPO_PRIVATE" = "false" ]; then
-          echo -e "\033[32m✓ Free for public repositories\033[0m"
+          printf '\033[32m\342\234\223 Free for public repositories\033[0m\n'
         fi
-        echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
-        echo ""
+        printf '\033[36mLearn more:\033[0m %s\n' "$DOCS_URL"
+        printf '\n'
 
         if [ "$REPO_PRIVATE" != "false" ]; then
           SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
@@ -41,15 +41,15 @@ runs:
             -d "$BODY" \
             "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
 
-          if [ $CURL_EXIT_CODE -ne 0 ]; then
+          if [ "$CURL_EXIT_CODE" -ne 0 ]; then
             echo "Timeout or API not reachable. Continuing to next step."
           elif [ "$RESPONSE" = "403" ]; then
-            echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
-            echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+            printf '::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m\n' >&2
+            printf '::error::\033[31mLearn how to enable a subscription: %s\033[0m\n' "$DOCS_URL" >&2
             exit 1
           fi
         fi
-      shell: bash
+      shell: sh
     - name: install reviewdog
       run: |
         set -eu

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,49 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Subscription check
+      env:
+        REPO_PRIVATE: ${{ github.event.repository.private }}
+      run: |
+        UPSTREAM="reviewdog/action-setup"
+        ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+        DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
+
+        echo ""
+        echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+        echo "Secure drop-in replacement for $UPSTREAM"
+        if [ "$REPO_PRIVATE" = "false" ]; then
+          echo -e "\033[32m✓ Free for public repositories\033[0m"
+        fi
+        echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+        echo ""
+
+        if [ "$REPO_PRIVATE" != "false" ]; then
+          SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+          if [ "$SERVER_URL" != "https://github.com" ]; then
+            BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+          else
+            BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+          fi
+
+          API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+          RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+          if [ $CURL_EXIT_CODE -ne 0 ]; then
+            echo "Timeout or API not reachable. Continuing to next step."
+          elif [ "$RESPONSE" = "403" ]; then
+            echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+            echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+            exit 1
+          fi
+        fi
+      shell: bash
     - name: install reviewdog
       run: |
         set -eu

--- a/install.sh
+++ b/install.sh
@@ -1,24 +1,5 @@
 #!/bin/sh
 
-# validate subscription status
-API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/subscription"
-
-# Set a timeout for the curl command (3 seconds)
-RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" "$API_URL" -o /dev/null) || true
-CURL_EXIT_CODE=${?}
-
-# Check if the response code is not 200
-if [ $CURL_EXIT_CODE -ne 0 ]; then
-  echo "Timeout or API not reachable. Continuing to next step."
-elif [ "$RESPONSE" = "200" ]; then
-  :
-elif [ "$RESPONSE" = "403" ]; then
-  echo "Subscription is not valid. Reach out to support@stepsecurity.io"
-  exit 1
-else
-  echo "Timeout or API not reachable. Continuing to next step."
-fi
-
 set -eu
 
 VERSION="${REVIEWDOG_VERSION:-latest}"


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24 (if applicable)
- Updated workflow files with configurable node_version input (if applicable)

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated 3 workflow files, rebuilt dist/
- **Docker actions**: replaced entrypoint.sh subscription block, ensured jq is installed in Dockerfile
- **Composite actions**: added Subscription check step to action.yml

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260423T092801Z